### PR TITLE
Update element.rst to include RockingBC

### DIFF
--- a/source/user/manual/model/element.rst
+++ b/source/user/manual/model/element.rst
@@ -195,4 +195,5 @@ The following subsections contain information about **$eleType** and the number 
    elements/AV3D4
    elements/ASDEmbeddedNodeElement
    elements/ASDAbsorbingBoundary
+   elements/RockingBC
 


### PR DESCRIPTION
Realized that I hadn't updated the list of elements so RockingBC didn't show up.
The element is highly related to contact, but isn't zero-length, so maybe it's best to go to Misc.
Thank you!