### PR TITLE
Update uniaxialMaterial.rst

### DIFF
--- a/source/user/manual/material/uniaxialMaterial.rst
+++ b/source/user/manual/material/uniaxialMaterial.rst
@@ -44,20 +44,21 @@ The following subsections contain information about **$matType**
       uniaxialMaterials/Concrete01
       uniaxialMaterials/Concrete02
       uniaxialMaterials/Concrete04
-      uniaxialMaterials/Concrete06
+      uniaxialMaterials/GMG_CyclicReinforcedConcrete
+	  
+..    uniaxialMaterials/Concrete06
       uniaxialMaterials/Concrete07
       uniaxialMaterials/ConfinedConcrete01
       uniaxialMaterials/ConcreteD
       uniaxialMaterials/FRPConfinedConcrete
       uniaxialMaterials/ConcreteCM
-      uniaxialMaterials/GMG_CyclicReinforcedConcrete
 
 #. Some Standard Uniaxial Materials
 
-   .. toctree::
+.. toctree::
       :maxdepth: 1
 		 
-      uniaxialMaterials/Elastic
+..    uniaxialMaterials/Elastic
       uniaxialMaterials/ElasticPP
       uniaxialMaterials/ElasticPP_Gap
       uniaxialMaterials/ElasticNoTension
@@ -76,15 +77,17 @@ The following subsections contain information about **$matType**
       uniaxialMaterials/IMKBilin
       uniaxialMaterials/IMKPeakOriented
       uniaxialMaterials/IMKPinching
-      uniaxialMaterials/Pinching4
       uniaxialMaterials/SLModel
+	  
+..    uniaxialMaterials/Pinching4
+
       
 #. Wrapper Uniaxial Materials
 
-   .. toctree::
+.. toctree::
       :maxdepth: 1
       
-      uniaxialMaterials/Fatigue
+..    uniaxialMaterials/Fatigue
       uniaxialMaterials/Parallel
       uniaxialMaterials/Series
       uniaxialMaterials/InitialStrain
@@ -97,7 +100,17 @@ The following subsections contain information about **$matType**
    .. toctree::
       :maxdepth: 1
 
-      uniaxialMaterials/CastFuse
+      uniaxialMaterials/BoucWenInfill
+      uniaxialMaterials/HystereticPoly
+      uniaxialMaterials/HystereticAsym
+      uniaxialMaterials/HystereticSmooth
+      uniaxialMaterials/DowelType
+      uniaxialMaterials/CoulombDamper
+      uniaxialMaterials/HertzDamp
+      uniaxialMaterials/JankowskiImpact
+      uniaxialMaterials/ViscoelasticGap
+
+..    uniaxialMaterials/CastFuse
       uniaxialMaterials/ViscousDamper
       uniaxialMaterials/BilinearOilDamper
       uniaxialMaterials/SAWS
@@ -111,16 +124,6 @@ The following subsections contain information about **$matType**
       uniaxialMaterials/Viscous
       uniaxialMaterials/BoucWen
       uniaxialMaterials/BWBN (Pinching Hysteretic Bouc-Wen)
-      uniaxialMaterials/HystereticPoly
-      uniaxialMaterials/HystereticAsym (Smooth asymmetric hysteresis)
-      uniaxialMaterials/HystereticPoly
-      uniaxialMaterials/HystereticSmooth (Smooth hysteretic material)
-      uniaxialMaterials/DowelType
-      uniaxialMaterials/BoucWenInfill
-      uniaxialMaterials/CoulombDamper
-      uniaxialMaterials/HertzDamp
-      uniaxialMaterials/JankowskiImpact
-      uniaxialMaterials/ViscoelasticGap
 
 
 
@@ -135,16 +138,14 @@ The following subsections contain information about **$matType**
    uniaxialMaterials/PyLiq1
    uniaxialMaterials/TzLiq1
    uniaxialMaterials/QzLiq1
-   uniaxialMaterials/PySimple1Gen
-   uniaxialMaterials/TzSimple1Gen
 
-
-   uniaxialMaterials/KikuchiAikenHDR
+.. uniaxialMaterials/KikuchiAikenHDR
    uniaxialMaterials/KikuchiAikenLRB
    uniaxialMaterials/AxialSp
    uniaxialMaterials/AxialSpHD
    uniaxialMaterials/PinchingLimitState
    uniaxialMaterials/CFSWSWP
    uniaxialMaterials/CFSSSWP
-
+   uniaxialMaterials/PySimple1Gen
+   uniaxialMaterials/TzSimple1Gen
 


### PR DESCRIPTION
Hi,

Among compiling the rst files, many errors arise because of lack of existing rst files mentioned in the uniaxialMaterial.rst. Now they are just commented to avoid error messages and when the rst files provided then the comment sign will be remove.