### PR TITLE
Add documentation for PythonSparse interface

### DIFF
--- a/source/user/manual/analysis/eigen.rst
+++ b/source/user/manual/analysis/eigen.rst
@@ -12,7 +12,7 @@ This command is used to perform the eigenvalue analysis.
    :widths: 10, 10, 40
    
    $numEigenvalues, |integer|, number of eigenvalues required.
-   $solver, |string|, "optional string detailing type of solver: -genBandArpack (default), -fullGenLapack, -symmBandLapack."
+   $solver, |string|, "optional string detailing type of solver: -genBandArpack (default), -fullGenLapack, -symmBandLapack. Python users may also use the :ref:`PythonSparse eigenvalue solver <eigenPythonSparse>`."
    $type, |string|, optional string indicating type of eigenvalue problem to solve: 'general' (default) or 'standard'
 
 .. admonition:: Returns
@@ -24,6 +24,7 @@ This command is used to perform the eigenvalue analysis.
    1.  The eigenvectors are stored at the nodes and can be printed out using a Node Recorder, the nodeEigenvector command, or the Print command.
    2.  The default eigensolver is able to solve only for N-1 eigenvalues, where N is the number of inertial DOFs. When running into this limitation the -fullGenLapack solver can be used instead of the default Arpack solver.
    3. The -symmBandLapack option works only standard eigenvalue analysis of the stiffness matrix, i.e., K*x = lam*x
+   4.  **Python users:** A :ref:`PythonSparse eigenvalue solver <eigenPythonSparse>` is available as well (OpenSeesPy only).
 
 
 .. warning::
@@ -152,5 +153,165 @@ Theory
 
       # obtain 10 eigenvalues of the stiffness matrix
       eigenvalues = eigen('standard','-symmBandLapack',10)
+
+      # PythonSparse: use a custom Python solver (e.g., SciPy eigsh)
+      eigenvalues = eigen('PythonSparse', 10, {'solver': solver, 'scheme': 'CSR'})
+
+PythonSparse Eigenvalue Solver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _eigenPythonSparse:
+
+The **PythonSparse** eigen solver delegates the generalized eigenvalue problem :math:`\mathbf{K}\phi = \lambda \mathbf{M}\phi` to user-defined Python objects. Sparse stiffness (K) and mass (M) matrix buffers are exposed via zero-copy memoryviews, enabling the use of SciPy, CuPy, or custom eigensolvers without recompiling OpenSees. See :ref:`example below <eigenPythonSparseExample>` for a SciPy eigsh implementation.
+
+.. function:: eigen PythonSparse $numEigenvalues <dict>?
+
+   Perform eigenvalue analysis using a user-defined Python solver. The dict is the solver configuration; keys below.
+
+.. csv-table::
+   :header: "Argument", "Type", "Description"
+   :widths: 12, 15, 53
+
+   $numEigenvalues, int, Number of eigenvalues (and eigenvectors) to compute.
+   dict, dict, Solver configuration; see dict options table below.
+
+.. csv-table::
+   :header: "Key", "Type", "Description"
+   :widths: 12, 15, 53
+
+   solver, Python object, "A Python object with a ``solve(**kwargs)`` method. Required."
+   scheme, string, "Sparse format: ``'CSR'``, ``'CSC'``, ``'COO'``. Default: ``'CSR'``."
+
+.. note::
+
+   The PythonSparse eigen interface is available only when using the Python interpreter (OpenSeesPy).
+
+The solver object must implement a ``solve(**kwargs)`` method. OpenSees passes the matrix data as keyword arguments: memoryviews (buffer-like objects) for arrays, and scalars for metadata. Use `numpy.frombuffer <https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html>`_ to interpret memoryviews as NumPy arrays without copying. The structure format depends on ``scheme``:
+
+**CSR/CSC format** — compressed storage uses ``index_ptr`` and ``indices``:
+
+.. csv-table::
+   :header: "Keyword", "Type", "Description"
+   :widths: 18, 15, 47
+
+   index_ptr, memoryview, "Row pointers (CSR) or column pointers (CSC), int32."
+   indices, memoryview, "Column indices (CSR) or row indices (CSC), int32."
+   k_values, memoryview, "Stiffness matrix K coefficients (float64)."
+   m_values, memoryview, "Mass matrix M coefficients (float64)."
+   eigenvalues, memoryview, "Output buffer for eigenvalues (float64, writable). Write *in place*."
+   eigenvectors, memoryview, "Output buffer for eigenvectors (float64, writable). Write *in place*, row-major: mode 0, mode 1, ..."
+   num_eqn, int, "Number of equations."
+   nnz, int, "Number of nonzeros (K and M share sparsity pattern)."
+   matrix_status, string, "``'UNCHANGED'``, ``'COEFFICIENTS_CHANGED'``, or ``'STRUCTURE_CHANGED'``."
+   storage_scheme, string, "``'CSR'``, ``'CSC'``, or ``'COO'``."
+   num_modes, int, "Number of modes requested."
+   generalized, bool, "True for generalized (K, M); False for standard (K only)."
+   find_smallest, bool, "True: smallest eigenvalues (e.g., frequency); False: largest."
+
+**COO format** — coordinate storage uses ``row_indices`` and ``col_indices`` instead of ``index_ptr``/``indices``:
+
+.. csv-table::
+   :header: "Keyword", "Type", "Description"
+   :widths: 18, 15, 47
+
+   row_indices, memoryview, "Row indices for each nonzero, int32 (COO only)."
+   col_indices, memoryview, "Column indices for each nonzero, int32 (COO only)."
+   k_values, memoryview, "Stiffness matrix K coefficients (float64)."
+   m_values, memoryview, "Mass matrix M coefficients (float64)."
+   eigenvalues, memoryview, "Output buffer for eigenvalues (float64, writable). Write *in place*."
+   eigenvectors, memoryview, "Output buffer for eigenvectors (float64, writable). Write *in place*."
+   num_eqn, int, "Number of equations."
+   nnz, int, "Number of nonzeros."
+   matrix_status, string, "``'UNCHANGED'``, ``'COEFFICIENTS_CHANGED'``, or ``'STRUCTURE_CHANGED'``."
+   storage_scheme, string, "``'COO'``."
+   num_modes, int, "Number of modes requested."
+   generalized, bool, "True for generalized (K, M); False for standard (K only)."
+   find_smallest, bool, "True: smallest eigenvalues; False: largest."
+
+The ``solve`` method should return ``None`` on success, or raise an exception on failure.
+
+.. warning:: **In-place output required**
+
+   You **must** write eigenvalues and eigenvectors directly into the ``eigenvalues`` and ``eigenvectors`` buffers. OpenSees reads from these buffers; it does **not** use return values.
+
+   **Do:** Use in-place assignment, e.g. ``np.frombuffer(eigenvalues, ...)[:] = eigvals`` and ``np.frombuffer(eigenvectors, ...)[:] = eigvecs.T.flatten()``
+
+   **Do not:** Return the results or assign to new arrays without copying back into the buffers. OpenSees will use uninitialized or stale data.
+
+.. _eigenPythonSparseExample:
+
+.. admonition:: Example — SciPy Generalized Eigenvalue Solver
+
+   This example uses `SciPy <https://scipy.org/>`_ and its `eigsh <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html>`_ (ARPACK symmetric eigensolver) to solve the generalized eigenvalue problem:
+
+   .. code-block:: python
+
+      import numpy as np
+      import scipy.sparse as sp
+      import scipy.sparse.linalg as sp_linalg
+      import openseespy.opensees as ops
+
+      class SciPyGeneralizedEigenSolver:
+          def __init__(self, maxiter=None, tol=0.0):
+              self.maxiter = maxiter
+              self.tol = tol
+              self._k_matrix = None
+              self._m_matrix = None
+
+          def solve(self, **kwargs):
+              index_ptr = kwargs['index_ptr']
+              indices = kwargs['indices']
+              k_values = kwargs['k_values']
+              m_values = kwargs['m_values']
+              eigenvalues = kwargs['eigenvalues']
+              eigenvectors = kwargs['eigenvectors']
+              num_eqn = kwargs['num_eqn']
+              nnz = kwargs['nnz']
+              matrix_status = kwargs['matrix_status']
+              num_modes = kwargs['num_modes']
+              find_smallest = kwargs['find_smallest']
+
+              indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
+              idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
+              k_data = np.frombuffer(k_values, dtype=np.float64, count=nnz)
+              m_data = np.frombuffer(m_values, dtype=np.float64, count=nnz)
+
+              if matrix_status == 'STRUCTURE_CHANGED' or self._k_matrix is None:
+                  self._k_matrix = sp.csr_matrix((k_data, idx, indptr),
+                                                shape=(num_eqn, num_eqn))
+                  self._m_matrix = sp.csr_matrix((m_data, idx, indptr),
+                                                shape=(num_eqn, num_eqn))
+              elif matrix_status == 'COEFFICIENTS_CHANGED':
+                  self._k_matrix.data[:] = k_data
+                  self._m_matrix.data[:] = m_data
+
+              eigsh_kwargs = {
+                  'k': num_modes,
+                  'M': self._m_matrix,
+                  'which': 'LM',
+              }
+              if find_smallest:
+                  eigsh_kwargs['sigma'] = 0.0
+              if self.maxiter is not None:
+                  eigsh_kwargs['maxiter'] = self.maxiter
+              if self.tol > 0.0:
+                  eigsh_kwargs['tol'] = self.tol
+
+              eigvals, eigvecs = sp_linalg.eigsh(self._k_matrix, **eigsh_kwargs)
+
+              np.frombuffer(eigenvalues, dtype=np.float64,
+                            count=num_modes)[:] = eigvals[:num_modes]
+              np.frombuffer(eigenvectors, dtype=np.float64,
+                            count=num_modes * num_eqn)[:] = eigvecs.T.flatten()
+
+              return None
+
+      solver = SciPyGeneralizedEigenSolver()
+      eigenvalues = ops.eigen('PythonSparse', 10, {'solver': solver, 'scheme': 'CSR'})
+
+.. seealso::
+
+   * :ref:`systemPythonSparse` — PythonSparse interface for linear systems
+   * The `EXAMPLES/SolverBenchmark <https://github.com/OpenSees/OpenSees/blob/master/EXAMPLES/SolverBenchmark/benchmark_python_sparse_eigen.py>`_ script demonstrates the PythonSparse eigen solver.
 
 Code Developed by: |fmk|

--- a/source/user/manual/analysis/system.rst
+++ b/source/user/manual/analysis/system.rst
@@ -22,3 +22,4 @@ The following contain information about systemType? and the args required for ea
    system/SparseSYM
    system/Mumps
    system/Cusp
+   system/PythonSparse

--- a/source/user/manual/analysis/system/PythonSparse.rst
+++ b/source/user/manual/analysis/system/PythonSparse.rst
@@ -1,0 +1,171 @@
+.. _systemPythonSparse:
+
+PythonSparse System
+------------------
+
+The **PythonSparse** system delegates linear system solves (:math:`\mathbf{A}\mathbf{x} = \mathbf{b}`) to user-defined Python objects. Sparse matrix buffers (CSR, CSC, or COO format) are exposed to Python via zero-copy memoryviews, enabling efficient integration with SciPy, CuPy, nvmath, or custom solvers without writing C++ wrappers or recompiling OpenSees. See :ref:`CuPy (GPU) <pythonSparseExampleCupy>` and :ref:`SciPy (CPU) <pythonSparseExampleScipy>` examples below.
+
+.. function:: system PythonSparse <dict>?
+
+   Create a linear system that forwards sparse matrix data to a Python solver object. The dict is the solver configuration; see table below.
+
+.. csv-table::
+   :header: "Key", "Type", "Description"
+   :widths: 12, 15, 53
+
+   solver, Python object, "A Python object with a ``solve(**kwargs)`` method. Required."
+   scheme, string, "Sparse format: ``'CSR'``, ``'CSC'``, ``'COO'``. Default: ``'CSR'``."
+   writable, string or list, "Buffers the solver may modify: ``'values'`` (matrix coefficients), ``'rhs'`` (right-hand side), ``'values,rhs'`` or ``'all'``, or ``'none'``. Also accepts list form: ``['values', 'rhs']``. Default: ``'none'`` — only the solution buffer ``x`` is writable."
+
+.. note::
+
+   The PythonSparse interface is available only when using the Python interpreter (OpenSeesPy). Enabling ``writable`` for ``values`` or ``rhs`` allows in-place updates of the stiffness matrix and right-hand side vector; use only if you know what you are doing.
+
+The solver object must implement a ``solve(**kwargs)`` method. OpenSees passes the matrix data as keyword arguments: memoryviews (buffer-like objects) for arrays, and scalars for metadata. Use `numpy.frombuffer <https://numpy.org/doc/stable/reference/generated/numpy.frombuffer.html>`_ to interpret memoryviews as NumPy arrays without copying. The structure format depends on ``scheme``:
+
+**CSR/CSC format** — compressed storage uses ``index_ptr`` and ``indices``:
+
+.. csv-table::
+   :header: "Keyword", "Type", "Description"
+   :widths: 18, 15, 47
+
+   index_ptr, memoryview, "Row pointers (CSR) or column pointers (CSC), int32."
+   indices, memoryview, "Column indices (CSR) or row indices (CSC), int32."
+   values, memoryview, "Matrix coefficients (float64)."
+   rhs, memoryview, "Right-hand side vector (float64)."
+   x, memoryview, "Solution buffer (float64, writable). Write the solution *in place*."
+   num_eqn, int, "Number of equations."
+   nnz, int, "Number of nonzeros."
+   matrix_status, string, "``'UNCHANGED'``, ``'COEFFICIENTS_CHANGED'``, or ``'STRUCTURE_CHANGED'``."
+   storage_scheme, string, "``'CSR'``, ``'CSC'``, or ``'COO'`` — which format was used."
+
+**COO format** — coordinate storage uses ``row`` and ``col`` instead of ``index_ptr``/``indices``:
+
+.. csv-table::
+   :header: "Keyword", "Type", "Description"
+   :widths: 18, 15, 47
+
+   row, memoryview, "Row indices for each nonzero, int32 (COO only)."
+   col, memoryview, "Column indices for each nonzero, int32 (COO only)."
+   values, memoryview, "Matrix coefficients (float64)."
+   rhs, memoryview, "Right-hand side vector (float64)."
+   x, memoryview, "Solution buffer (float64, writable). Write the solution *in place*."
+   num_eqn, int, "Number of equations."
+   nnz, int, "Number of nonzeros."
+   matrix_status, string, "``'UNCHANGED'``, ``'COEFFICIENTS_CHANGED'``, or ``'STRUCTURE_CHANGED'``."
+   storage_scheme, string, "``'COO'``."
+
+The ``solve`` method should return ``0`` on success, or a negative value to indicate failure.
+
+.. warning:: **In-place output required**
+
+   You **must** write the solution directly into the ``x`` buffer. OpenSees uses this buffer; it does **not** use return values or new arrays.
+
+   **Do:** Use in-place assignment, e.g. ``np.frombuffer(x, dtype=np.float64, count=num_eqn)[:] = result``
+
+   **Do not:** Return the solution, assign to a new variable, or write to a copy. The result will be ignored and the analysis will use uninitialized or stale data.
+
+.. _pythonSparseExampleCupy:
+
+.. admonition:: Example — CuPy Conjugate Gradient (GPU)
+
+   This example uses `CuPy <https://cupy.dev/>`_ and its `cg <https://docs.cupy.dev/en/stable/reference/generated/cupyx.scipy.sparse.linalg.cg.html>`_ (conjugate gradient) solver to solve the linear system on an NVIDIA GPU. Note the use of ``np.frombuffer(array, dtype)[:] = result`` to write the solution in place:
+
+   .. code-block:: python
+
+      import numpy as np
+      import cupy as cp
+      import cupyx.scipy.sparse.linalg
+      import openseespy.opensees as ops
+
+      class CuPyCGSolver:
+          def __init__(self, rtol=1e-5, atol=1e-12, maxiter=None):
+              self.rtol = rtol
+              self.atol = atol
+              self.maxiter = maxiter
+              self.A = None
+
+          def solve(self, **kwargs):
+              index_ptr = kwargs['index_ptr']
+              indices = kwargs['indices']
+              values = kwargs['values']
+              rhs = kwargs['rhs']
+              x = kwargs['x']
+              num_eqn = kwargs['num_eqn']
+              nnz = kwargs['nnz']
+              matrix_status = kwargs['matrix_status']
+
+              indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
+              idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
+              vals = np.frombuffer(values, dtype=np.float64, count=nnz)
+
+              if matrix_status == 'STRUCTURE_CHANGED' or self.A is None:
+                  self.A = cp.sparse.csr_matrix(
+                      (cp.asarray(vals), cp.asarray(idx), cp.asarray(indptr)),
+                      shape=(num_eqn, num_eqn)
+                  )
+              elif matrix_status == 'COEFFICIENTS_CHANGED':
+                  self.A.data[:] = cp.asarray(vals)
+
+              rhs_gpu = cp.asarray(np.frombuffer(rhs, dtype=np.float64, count=num_eqn))
+              x_gpu, info = cupyx.scipy.sparse.linalg.cg(
+                  self.A, rhs_gpu, tol=self.rtol, atol=self.atol, maxiter=self.maxiter
+              )
+
+              np.frombuffer(x, dtype=np.float64, count=num_eqn)[:] = cp.asnumpy(x_gpu)
+              return -int(info)
+
+      solver = CuPyCGSolver(rtol=1e-8, atol=1e-12, maxiter=1000)
+      ops.system('PythonSparse', {'solver': solver, 'scheme': 'CSR'})
+
+.. _pythonSparseExampleScipy:
+
+.. admonition:: Example — SciPy Direct Solve (CPU)
+
+   This example uses `SciPy <https://scipy.org/>`_ and its `factorized <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.factorized.html>`_ (sparse LU factorization) for a direct solve on CPU:
+
+   .. code-block:: python
+
+      import numpy as np
+      import scipy.sparse as sp
+      import scipy.sparse.linalg as sp_linalg
+      import openseespy.opensees as ops
+
+      class SciPyspSolveSolver:
+          def __init__(self):
+              self.A = None
+              self._solve_func = None
+
+          def solve(self, **kwargs):
+              index_ptr = kwargs['index_ptr']
+              indices = kwargs['indices']
+              values = kwargs['values']
+              rhs = kwargs['rhs']
+              x = kwargs['x']
+              num_eqn = kwargs['num_eqn']
+              nnz = kwargs['nnz']
+              matrix_status = kwargs['matrix_status']
+
+              indptr = np.frombuffer(index_ptr, dtype=np.int32, count=num_eqn + 1)
+              idx = np.frombuffer(indices, dtype=np.int32, count=nnz)
+              vals = np.frombuffer(values, dtype=np.float64, count=nnz)
+
+              if matrix_status != 'UNCHANGED' or self._solve_func is None:
+                  self.A = sp.csr_matrix((vals.copy(), idx.copy(), indptr.copy()),
+                                        shape=(num_eqn, num_eqn))
+                  self._solve_func = sp_linalg.factorized(self.A)
+
+              rhs_arr = np.frombuffer(rhs, dtype=np.float64, count=num_eqn)
+              x_arr = np.frombuffer(x, dtype=np.float64, count=num_eqn)
+              x_arr[:] = self._solve_func(rhs_arr)
+              return 0
+
+      solver = SciPyspSolveSolver()
+      ops.system('PythonSparse', {'solver': solver, 'scheme': 'CSR'})
+
+Code developed by: `gaaraujo <https://github.com/gaaraujo>`_
+
+.. seealso::
+
+   * :ref:`eigenPythonSparse` — PythonSparse interface for generalized eigenvalue problems
+   * The `EXAMPLES/SolverBenchmark <https://github.com/OpenSees/OpenSees/blob/master/EXAMPLES/SolverBenchmark/benchmark_python_sparse.py>`_ script in the OpenSees repository benchmarks PythonSparse against native solvers.


### PR DESCRIPTION
Documentation for the PythonSparse interface added in [OpenSees PR #1676](https://github.com/OpenSees/OpenSees/pull/1676).
